### PR TITLE
Mopidy 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+/ct-Raspi-Radiowecker.iml

--- a/install.md
+++ b/install.md
@@ -28,7 +28,7 @@ sudo ./LCD5-show
 ## Mopidy-Addons nachinstallieren
 
 ```
-sudo pip install Mopidy-Iris Mopidy-ALSAMixer 
+sudo python3 -m pip install Mopidy-Mobile Mopidy-ALSAMixer 
 ```
 
 ## Python-Umgebung für das Touch-Interface einrichten

--- a/mopidy.py
+++ b/mopidy.py
@@ -121,26 +121,26 @@ class MusicPlayer(object):
     def getVolume(self):
         try:
             self.volume = int(self._clientRequest(
-                "core.playback.get_volume")["result"])
+                "core.mixer.get_volume")["result"])
             self.muted = bool(self._clientRequest(
-                "core.playback.get_mute")["result"])
+                "core.mixer.get_mute")["result"])
         except Exception as e:
             print(e)
             self.volume = 100
             self.muted = False
 
     def toggleMute(self):
-        self._clientRequest("core.playback.set_mute", {"mute": not self.muted})
+        self._clientRequest("core.mixer.set_mute", {"mute": not self.muted})
         self.muted = bool(self._clientRequest(
-            "core.playback.get_mute")["result"])
+            "core.mixer.get_mute")["result"])
 
     def volup(self):
-        self._clientRequest("core.playback.set_volume", {
+        self._clientRequest("core.mixer.set_volume", {
                             "volume": self.volume + 10})
         self.getVolume()
 
     def voldown(self):
-        self._clientRequest("core.playback.set_volume", {
+        self._clientRequest("core.mixer.set_volume", {
                             "volume": self.volume - 10})
         self.getVolume()
 


### PR DESCRIPTION
Dieser Patch löst zwei Probleme mit Mopidy 3.0
1. Iris läuft nicht mit Mopidy 3.0, da Mopidy 3.0 voraussetzt, dass Extensions unter  Python3 laufen. [Blog Post zu Mopidy3](https://mopidy.com/blog/2019/12/22/mopidy-3.0/)
2. Die Lautstärke wird über den MixerController gesteuert. Nicht wie früher über den [PlaybackController](https://docs.mopidy.com/en/latest/api/core/#playback-controller)

